### PR TITLE
Rewritten version of paired_read_merger

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,8 @@
+To test paired reads merger written by Egor Bogomolov, after installation of IgReC use following command:
+./build/release/bin/paired_read_merger --1 test_dataset/left.fastq --2 test_dataset/right.fastq --o test_dataset/merged_reads.fastq --bad test_dataset/bad_reads.fastq
+To feel the difference between different merger settings, use following flag:
+--max-mismatch=0.0001
+
 IgRepertoireConstructor
 Algorithm for construction of antibody repertoire from NGS data and immunoproteogenomics analysis
 Version: see VERSION

--- a/src/paired_read_merger/CMakeLists.txt
+++ b/src/paired_read_merger/CMakeLists.txt
@@ -6,6 +6,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${SPADES_MAIN_INCLUDE_DIR})
 include_directories(${SPADES_MAIN_SRC_DIR}/ig_tools)
 
+link_libraries(boost_program_options)
 link_libraries(input yaml-cpp ${COMMON_LIBRARIES})
 link_libraries(boost_iostreams)
 add_executable(paired_read_merger main.cpp)

--- a/src/paired_read_merger/main.cpp
+++ b/src/paired_read_merger/main.cpp
@@ -1,17 +1,15 @@
 #include "reads_merger.hpp"
-#include <utils/string_tools.hpp>
 
-#include "logger/log_writers.hpp"
 #include <boost/program_options.hpp>
 
 namespace po = boost::program_options;
 namespace rm = reads_merger;
 
 void create_console_logger(string log_filename) {
-    using namespace logging;
-    logger *lg = create_logger(path::FileExists(log_filename) ? log_filename : "");
-    lg->add_writer(std::make_shared<console_writer>());
-    attach_logger(lg);
+	using namespace logging;
+	logger *lg = create_logger(path::FileExists(log_filename) ? log_filename : "");
+	lg->add_writer(std::make_shared<console_writer>());
+	attach_logger(lg);
 }
 
 int main(int argc, char *argv[]) {
@@ -28,11 +26,12 @@ int main(int argc, char *argv[]) {
 		("help", "Help message")
 		("min-overlap", po::value<size_t>(&settings.min_overlap)->default_value(50), "set minimal overlap size")
 		("max-mismatch", po::value<double>(&settings.max_mismatch_rate)->default_value(0.1), "set maximal mismatch rate")
-		("1", po::value< vector<string> >(&in_left_files), "input files containing left reads")
-		("2", po::value< vector<string> >(&in_right_files), "input files containing right reads")
-		("o", po::value< string >(&out_good_file), "output file for merged reads")
-		("bad", po::value< string >(&out_bad_file), "output file for non-merged reads")
-	;
+		("1", po::value<vector<string>>(&in_left_files), "input files containing left reads")
+		("2", po::value<vector<string>>(&in_right_files), "input files containing right reads")
+		("o", po::value<string>(&out_good_file), "output file for merged reads")
+		("bad", po::value<string>(&out_bad_file), "output file for non-merged reads")
+		("qual", po::value<size_t>(&settings.base_quality)->default_value(33), "set base quality")
+		;
 	po::variables_map vm;
 	po::store(po::parse_command_line(argc, argv, desc), vm);
 	po::notify(vm);    
@@ -42,10 +41,10 @@ int main(int argc, char *argv[]) {
 		return 1;
 	}
 	if (in_left_files.size() != in_right_files.size()) {
+		INFO("Numbers of files with left and right reads are different.");
 		return 2;
 	}
 	//end parsing
-
 	seqan::SeqFileOut out_good(out_good_file.c_str());
 	seqan::SeqFileOut out_bad;
 	if (vm.count("bad")) {

--- a/src/paired_read_merger/main.cpp
+++ b/src/paired_read_merger/main.cpp
@@ -65,8 +65,9 @@ int main(int argc, char *argv[]) {
 			left.read(in_left);
 			right.read(in_right);
 			right.reverseRead();
-			pair <rm::Read, bool> result = merger.Merge<rm::SuffArrayPairer>(left,right, settings, cnt_all);	
+	//		pair <rm::Read, bool> result = merger.Merge<rm::SuffArrayPairer>(left,right, settings, cnt_all);	
 		//	pair <rm::Read, bool> result = merger.Merge<rm::SimplePairer>(left,right, settings, cnt_all);	
+			pair <rm::Read, bool> result = merger.Merge<rm::KHashPairer>(left,right, settings, cnt_all);	
 			if (result.second) {
 				result.first.write(out_good);
 				++cnt_good;

--- a/src/paired_read_merger/main.cpp
+++ b/src/paired_read_merger/main.cpp
@@ -13,6 +13,7 @@ void create_console_logger(string log_filename) {
 }
 
 int main(int argc, char *argv[]) {
+
 	vector<string> in_left_files, in_right_files;
 	string out_good_file;
 	string out_bad_file;
@@ -44,6 +45,10 @@ int main(int argc, char *argv[]) {
 		INFO("Numbers of files with left and right reads are different.");
 		return 2;
 	}
+	if (in_left_files.size() == 0) {
+		INFO("No files to read from.");
+		return 2;
+	}
 	//end parsing
 	seqan::SeqFileOut out_good(out_good_file.c_str());
 	seqan::SeqFileOut out_bad;
@@ -52,7 +57,6 @@ int main(int argc, char *argv[]) {
 	}
 	rm::Read left, right, result;
 	rm::SequenceMerger merger;
-	rm::SimplePairer pairer(settings); 
 	int cnt_good = 0, cnt_all = 0;
 	for (size_t i = 0; i < in_left_files.size(); ++i) {
 		seqan::SeqFileIn in_left(in_left_files[i].c_str());
@@ -61,7 +65,8 @@ int main(int argc, char *argv[]) {
 			left.read(in_left);
 			right.read(in_right);
 			right.reverseRead();
-			pair <rm::Read, bool> result = merger.Merge(left,right, pairer, cnt_all);	
+			pair <rm::Read, bool> result = merger.Merge<rm::SuffArrayPairer>(left,right, settings, cnt_all);	
+		//	pair <rm::Read, bool> result = merger.Merge<rm::SimplePairer>(left,right, settings, cnt_all);	
 			if (result.second) {
 				result.first.write(out_good);
 				++cnt_good;

--- a/src/paired_read_merger/main.cpp
+++ b/src/paired_read_merger/main.cpp
@@ -65,9 +65,10 @@ int main(int argc, char *argv[]) {
 			left.read(in_left);
 			right.read(in_right);
 			right.reverseRead();
-	//		pair <rm::Read, bool> result = merger.Merge<rm::SuffArrayPairer>(left,right, settings, cnt_all);	
+		//	pair <rm::Read, bool> result = merger.Merge<rm::SuffArrayPairer>(left,right, settings, cnt_all);	
 		//	pair <rm::Read, bool> result = merger.Merge<rm::SimplePairer>(left,right, settings, cnt_all);	
-			pair <rm::Read, bool> result = merger.Merge<rm::KHashPairer>(left,right, settings, cnt_all);	
+		//	pair <rm::Read, bool> result = merger.Merge<rm::KHashPairer>(left,right, settings, cnt_all);	
+			pair <rm::Read, bool> result = merger.Merge<rm::SmartKHashPairer>(left,right, settings, cnt_all);	
 			if (result.second) {
 				result.first.write(out_good);
 				++cnt_good;

--- a/src/paired_read_merger/reads_merger.hpp
+++ b/src/paired_read_merger/reads_merger.hpp
@@ -1,11 +1,47 @@
 #pragma once
-
 #include <utils/fastq_reader.hpp>
 #include <utils/include_me.hpp>
 #include <utils/sequence_tools.hpp>
 #include <utils/string_tools.hpp>
 
 #include "logger/log_writers.hpp"
+
+#include <fstream>
+
+#include <seqan/seq_io.h>
+#include <seqan/sequence.h>
+#include <seqan/basic.h>
+
+namespace reads_merger {
+
+using namespace seqan;
+using namespace std;
+
+const size_t INFTY = size_t(-1);
+const char worst_quality = char(33);
+
+class Read {
+public:
+	CharString id, qual; 
+	Dna5String seq;
+
+	Read() = default;
+	Read(const CharString &new_id, const CharString &new_qual, const Dna5String &new_seq) {
+		id = new_id;
+		qual = new_qual;
+		seq = new_seq;
+	}
+	void read(SeqFileIn &in) {	
+		readRecord(id, seq, qual, in);
+	} 
+	inline void reverseRead() {
+		reverseComplement(seq);
+		reverse(qual);
+	}	
+	void write(SeqFileOut &out) {
+		writeRecord(out, id, seq, qual);
+	}
+};
 
 struct merger_setting {
     size_t min_overlap;
@@ -16,128 +52,116 @@ struct merger_setting {
         min_overlap(50),
         max_mismatch_rate(.1),
         simulated_mode(false) { }
-
     void print() {
         INFO("Min overlap size: " << min_overlap);
         INFO("Max mismatch rate: " << max_mismatch_rate);
-        if(simulated_mode)
+        if(simulated_mode) {
             INFO("Simulated mode is ON");
+		}
     }
+};
+
+struct PairerInfo {
+	size_t position;
+	PairerInfo(): position(INFTY) {}
+	PairerInfo(size_t pos): position(pos) {}
+};
+
+// вместо простого можно k-меры
+class SimplePairer {
+private:
+	merger_setting settings;
+	inline size_t hamming_distance(const Dna5String &s1, const Dna5String &s2, size_t pos) const {
+		size_t result = 0;		
+		for (size_t i = pos; i < length(s1) && i - pos < length(s2); ++i) {
+			if (s1[i] != s2[i - pos]) {
+				++result;
+			}
+		} 
+		return result;
+	} 
+public:
+	SimplePairer(const merger_setting &settings) : settings(settings) {}
+	PairerInfo find_best_overlap(const Dna5String &left, const Dna5String &right) const {
+		size_t best = INFTY, pos = INFTY; 
+		size_t llen = length(left), rlen = length(right);
+		for (size_t i = 0; i < llen; ++i) {
+			size_t overlap = min(llen - i, rlen);
+			if (overlap < settings.min_overlap) {
+				break;
+			}
+			size_t dist = hamming_distance(left, right, i);
+			if (double(dist) / double(overlap) <= settings.max_mismatch_rate && best > dist) {
+				best = dist, pos = i;
+			}
+		}
+		return PairerInfo(pos);
+	}
 };
 
 class SequenceMerger {
-    merger_setting setting_;
-
-    string reverse_quality_string(string qual) {
-        for(size_t i = 0; i < qual.size() / 2; i++) {
-            char tmp = qual[i];
-            qual[i] = qual[qual.size() - i - 1];
-            qual[qual.size() - i - 1] = tmp;
-        }
-        return qual;
-    }
-
-    pair<size_t, size_t> FindBestOverlap(string seq1, string seq2) {
-        pair<size_t, size_t> best_overlap(size_t(-1), size_t(-1));
-        for(size_t i = 0; i < seq1.size(); i++) {
-            size_t overlap_size = min<size_t>(seq2.size(), seq1.size() - i);
-            if(overlap_size >= setting_.min_overlap) {
-                string subseq1 = seq1.substr(i, overlap_size);
-                string subseq2 = seq2.substr(0, overlap_size);
-                size_t dist = HammingDistance(subseq1, subseq2);
-                double mism_rate = static_cast<double>(dist) / static_cast<double>(overlap_size);
-                if(mism_rate <= setting_.max_mismatch_rate) {
-                    if(best_overlap.first > dist) {
-                        best_overlap.first = dist;
-                        best_overlap.second = i;
-                    }
-                }
-            }
-        }
-        return best_overlap;
-    }
-
-    pair<string, string> MergeQualifiedSeq(paired_fastq_read &paired_read) {
-        string rc_right = reverse_complementary(paired_read.right_read.seq);
-        string left = paired_read.left_read.seq;
-        pair<size_t, size_t> overlap = FindBestOverlap(left, rc_right);
-        if(overlap == make_pair(size_t(-1), size_t(-1)))
-            return make_pair(string(), string());
-
-        size_t overlap_size = min<size_t>(left.size() - overlap.second,
-                rc_right.size());
-        string overlap_seq = left.substr(overlap.second, overlap_size);
-        string qual1 = paired_read.left_read.quality;
-        string qual2 = reverse_quality_string(paired_read.right_read.quality);
-        string overlap_qual = qual1.substr(overlap.second,
-                overlap_size);
-
-        if(!setting_.simulated_mode)
-            for(size_t i = 0; i < overlap_size; i++)
-                if(qual1[overlap.second + i] < qual2[i]) {
-                    overlap_seq[i] = rc_right[i];
-                    overlap_qual[i] = qual2[i];
-                }
-
-        string merged_seq = left.substr(0, overlap.second) + overlap_seq;
-        string merged_qual = qual1.substr(0, overlap.second) + overlap_qual;
-        if(overlap_size > rc_right.size()) {
-            merged_seq = merged_seq + left.substr(overlap.second + overlap_size,
-                    left.size() - overlap.second - overlap_size);
-            merged_qual = merged_qual + qual1.substr(overlap.second + overlap_size,
-                    left.size() - overlap.second - overlap_size);
-        }
-        else {
-            merged_seq = merged_seq + rc_right.substr(overlap_size,
-                    rc_right.size() - overlap_size);
-            merged_qual = merged_qual + qual2.substr(overlap_size,
-                    rc_right.size() - overlap_size );
-        }
-        assert(merged_seq.size() == merged_qual.size());
-        return make_pair(merged_seq, merged_qual);
-    }
-
-    string MergeNames(size_t index, string name1, string name2) {
-        name2 = ""; // Prevent warning
-        if(name1[0] == '@')
-            name1 = name1.substr(1, name1.size() - 1);
-        stringstream ss;
-        ss << "@" << index << "_merged_read_" << delete_spaces(name1);
-        return ss.str();
-    }
-
+private:
+	inline CharString merge_ids(const CharString &id, size_t index) {
+		string result;
+		result.resize(length(id));
+		for (size_t i = 0; i < length(id); ++i) {
+			if (id[i] == ' ') {
+				result[i] = '_';
+			} else {
+				result[i] = id[i];
+			}
+		}
+		return CharString(to_string(index) + "_merged_read_" + result);
+	}
+	inline Dna5String merge_seqs(const Dna5String &lseq, const Dna5String &rseq, 
+								 const CharString &lq, const CharString &rq, size_t pos) {
+		Dna5String result = lseq;
+		size_t llen = length(lseq), rlen = length(rseq);
+		for (size_t i = pos; i < min(llen, pos + rlen); ++i) {
+			if (result[i] == 'N') {
+				result[i] = rseq[i - pos];
+				continue;
+			}
+			if (lq[i] < rq[i - pos] && rq[i - pos] != 'N') {
+				result[i] = rseq[i - pos];
+			}
+		}
+		append(result, suffix(rseq, min(llen - pos, rlen)));
+		return result;
+	}
+	inline CharString merge_quals(const Dna5String &lseq, const Dna5String &rseq, 
+								  const CharString &lqual, const CharString &rqual, size_t pos) {
+		CharString result = lqual;
+		size_t llen = length(lseq), rlen = length(rseq);
+		for (size_t i = pos; i < min(llen, pos + rlen); ++i) {
+			if (lseq[i] == 'N' && rseq[i - pos] == 'N') {
+				result[i] = worst_quality;
+			} else if (lseq[i] == 'N') {
+				result[i] = rqual[i - pos];
+			} else if (rseq[i - pos] == 'N') {
+				result[i] = lqual[i];
+			} else if (lseq[i] == rseq[i - pos]) {
+				result[i] = char(lqual[i] - worst_quality + rqual[i - pos]);
+			} else if (lqual[i] < rqual[i - pos]) { 
+				result[i] = rqual[i - pos]; 
+			}
+		}
+		append(result, suffix(rqual, min(llen - pos, rlen)));
+		return result;
+	}
 public:
-    SequenceMerger(merger_setting setting) :
-        setting_(setting) { }
-
-    fastq_read Merge(size_t index, paired_fastq_read paired_read) {
-        string merged_name = MergeNames(index, paired_read.left_read.name,
-                paired_read.right_read.name);
-        pair<string, string> merged_seq_qual = MergeQualifiedSeq(paired_read);
-        return fastq_read(merged_name, merged_seq_qual.first,
-                merged_seq_qual.second);
-    }
+	template <class Pairer>
+	pair <Read, bool> Merge(const Read &left, const Read &right, const Pairer &pairer, size_t index) {
+		PairerInfo info = pairer.find_best_overlap(left.seq, right.seq);
+		if (info.position == INFTY) {
+			return (make_pair(Read(), false));
+		}
+		CharString new_id = merge_ids(left.id, index);
+		CharString new_qual = merge_quals(left.seq, right.seq, left.qual, right.qual, info.position);
+		Dna5String new_seq = merge_seqs(left.seq, right.seq, left.qual, right.qual, info.position);
+		assert(length(new_qual) == length(new_seq));
+		return make_pair(Read(new_id, new_qual, new_seq), true);
+	}
 };
 
-class PairedReadsMerger {
-    SequenceMerger seq_merger_;
-public:
-    PairedReadsMerger(merger_setting settings) :
-        seq_merger_(settings) { }
-
-    vector<fastq_read> Merge(vector<paired_fastq_read> reads) {
-        vector<fastq_read> merged_reads;
-        double processed_rate = 10;
-        for(size_t i = 0; i < reads.size(); i++) {
-            fastq_read merged_read = seq_merger_.Merge(i, reads[i]);
-            if(!merged_read.is_empty())
-                merged_reads.push_back(merged_read);
-            if(static_cast<double>(i) / static_cast<double>(reads.size()) * 100. > processed_rate) {
-                INFO(processed_rate << "% reads were processed");
-                processed_rate += 10;
-            }
-        }
-        INFO("100% reads were processed");
-        return merged_reads;
-    }
-};
+}

--- a/src/paired_read_merger/reads_merger.hpp
+++ b/src/paired_read_merger/reads_merger.hpp
@@ -89,10 +89,6 @@ namespace reads_merger {
 				}
 				return PairerInfo(pos);
 			}
-			
-			size_t quality() const {
-				return settings.base_quality;
-			}
 	};
 	
 	class SuffArrayPairer {
@@ -194,7 +190,7 @@ namespace reads_merger {
 				if (l > r) {
 					swap(l, r);
 				}
-				int lg = log[r - l];
+				int lg = log[r - l] - 1;
 				return min(sparse[l][lg], sparse[r - (1 << lg)][lg]);
 			}
 			
@@ -244,10 +240,6 @@ namespace reads_merger {
 					}
 				}
 				return PairerInfo(pos);
-			}
-			
-			size_t quality() const {
-				return settings.base_quality;
 			}
 	};
 
@@ -305,13 +297,16 @@ namespace reads_merger {
 			}
 		public:
 			template <class Pairer>
-				pair <Read, bool> Merge(const Read &left, const Read &right, const Pairer &pairer, size_t index) {
+				pair <Read, bool> Merge(const Read &left, const Read &right, const merger_setting &settings, size_t index) {
+					Pairer pairer(settings);
+			//		cerr << "Start pairing\n";
 					PairerInfo info = pairer.find_best_overlap(left.seq, right.seq);
+			//		cerr << "Finish pairing\n";
 					if (info.position == INFTY) {
 						return (make_pair(Read(), false));
 					}
 					CharString new_id = merge_ids(left.id, index);
-					CharString new_qual = merge_quals(left.seq, right.seq, left.qual, right.qual, info.position, pairer.quality());
+					CharString new_qual = merge_quals(left.seq, right.seq, left.qual, right.qual, info.position, settings.base_quality);
 					Dna5String new_seq = merge_seqs(left.seq, right.seq, left.qual, right.qual, info.position);
 					assert(length(new_qual) == length(new_seq));
 					return make_pair(Read(new_id, new_qual, new_seq), true);

--- a/src/paired_read_merger/reads_merger.hpp
+++ b/src/paired_read_merger/reads_merger.hpp
@@ -1,12 +1,7 @@
 #pragma once
-#include <utils/fastq_reader.hpp>
-#include <utils/include_me.hpp>
 #include <utils/sequence_tools.hpp>
-#include <utils/string_tools.hpp>
 
 #include "logger/log_writers.hpp"
-
-#include <fstream>
 
 #include <seqan/seq_io.h>
 #include <seqan/sequence.h>
@@ -14,154 +9,153 @@
 
 namespace reads_merger {
 
-using namespace seqan;
-using namespace std;
+	using namespace seqan;
+	using namespace std;
 
-const size_t INFTY = size_t(-1);
-const char worst_quality = char(33);
+	const size_t INFTY = size_t(-1);
 
-class Read {
-public:
-	CharString id, qual; 
-	Dna5String seq;
+	class Read {
+		public:
+			CharString id, qual; 
+			Dna5String seq;
 
-	Read() = default;
-	Read(const CharString &new_id, const CharString &new_qual, const Dna5String &new_seq) {
-		id = new_id;
-		qual = new_qual;
-		seq = new_seq;
-	}
-	void read(SeqFileIn &in) {	
-		readRecord(id, seq, qual, in);
-	} 
-	inline void reverseRead() {
-		reverseComplement(seq);
-		reverse(qual);
-	}	
-	void write(SeqFileOut &out) {
-		writeRecord(out, id, seq, qual);
-	}
-};
+			Read() = default;
+			Read(const CharString &new_id, const CharString &new_qual, const Dna5String &new_seq) {
+				id = new_id;
+				qual = new_qual;
+				seq = new_seq;
+			}
+			void read(SeqFileIn &in) {	
+				readRecord(id, seq, qual, in);
+			} 
+			void reverseRead() {
+				reverseComplement(seq);
+				reverse(qual);
+			}	
+			void write(SeqFileOut &out) {
+				writeRecord(out, id, seq, qual);
+			}
+	};
 
-struct merger_setting {
-    size_t min_overlap;
-    double max_mismatch_rate;
-    bool simulated_mode;
+	struct merger_setting {
+		size_t min_overlap;
+		size_t base_quality;
+		double max_mismatch_rate;
 
-    merger_setting() :
-        min_overlap(50),
-        max_mismatch_rate(.1),
-        simulated_mode(false) { }
-    void print() {
-        INFO("Min overlap size: " << min_overlap);
-        INFO("Max mismatch rate: " << max_mismatch_rate);
-        if(simulated_mode) {
-            INFO("Simulated mode is ON");
+		merger_setting() = default;
+		
+		void print() {
+			INFO("Min overlap size: " << min_overlap);
+			INFO("Max mismatch rate: " << max_mismatch_rate);
+			INFO("Base quality: " << base_quality);
 		}
-    }
-};
+	};
 
-struct PairerInfo {
-	size_t position;
-	PairerInfo(): position(INFTY) {}
-	PairerInfo(size_t pos): position(pos) {}
-};
+	struct PairerInfo {
+		size_t position;
+		PairerInfo(): position(INFTY) {}
+		PairerInfo(size_t pos): position(pos) {}
+	};
 
-// вместо простого можно k-меры
-class SimplePairer {
-private:
-	merger_setting settings;
-	inline size_t hamming_distance(const Dna5String &s1, const Dna5String &s2, size_t pos) const {
-		size_t result = 0;		
-		for (size_t i = pos; i < length(s1) && i - pos < length(s2); ++i) {
-			if (s1[i] != s2[i - pos]) {
-				++result;
+	// вместо простого можно k-меры
+	class SimplePairer {
+		private:
+			merger_setting settings;
+			size_t hamming_distance(const Dna5String &s1, const Dna5String &s2, size_t pos) const {
+				size_t result = 0;
+				size_t length1 = length(s1), length2 = length(s2);		
+				for (size_t i = pos; i < length1 && i - pos < length2; ++i) {
+					if (s1[i] != s2[i - pos]) {
+						++result;
+					}
+				} 
+				return result;
+			} 
+		public:
+			SimplePairer(const merger_setting &settings) : settings(settings) {}
+			PairerInfo find_best_overlap(const Dna5String &left, const Dna5String &right) const {
+				size_t best = INFTY, pos = INFTY; 
+				size_t left_len = length(left), right_len = length(right);
+				for (size_t i = 0; i < left_len; ++i) {
+					size_t overlap = min(left_len - i, right_len);
+					if (overlap < settings.min_overlap) {
+						break;
+					}
+					size_t dist = hamming_distance(left, right, i);
+					if (double(dist) / double(overlap) <= settings.max_mismatch_rate && best > dist) {
+						best = dist, pos = i;
+					}
+				}
+				return PairerInfo(pos);
 			}
-		} 
-		return result;
-	} 
-public:
-	SimplePairer(const merger_setting &settings) : settings(settings) {}
-	PairerInfo find_best_overlap(const Dna5String &left, const Dna5String &right) const {
-		size_t best = INFTY, pos = INFTY; 
-		size_t llen = length(left), rlen = length(right);
-		for (size_t i = 0; i < llen; ++i) {
-			size_t overlap = min(llen - i, rlen);
-			if (overlap < settings.min_overlap) {
-				break;
+			size_t quality() const {
+				return settings.base_quality;
 			}
-			size_t dist = hamming_distance(left, right, i);
-			if (double(dist) / double(overlap) <= settings.max_mismatch_rate && best > dist) {
-				best = dist, pos = i;
-			}
-		}
-		return PairerInfo(pos);
-	}
-};
+	};
 
-class SequenceMerger {
-private:
-	inline CharString merge_ids(const CharString &id, size_t index) {
-		string result;
-		result.resize(length(id));
-		for (size_t i = 0; i < length(id); ++i) {
-			if (id[i] == ' ') {
-				result[i] = '_';
-			} else {
-				result[i] = id[i];
+	class SequenceMerger {
+		private:
+			CharString merge_ids(const CharString &id, size_t index) {
+				string result;
+				size_t length_id = length(id);
+				result.resize(length_id);
+				for (size_t i = 0; i < length_id; ++i) {
+					if (id[i] == ' ') {
+						result[i] = '_';
+					} else {
+						result[i] = id[i];
+					}
+				}
+				return CharString(to_string(index) + "_merged_read_" + result);
 			}
-		}
-		return CharString(to_string(index) + "_merged_read_" + result);
-	}
-	inline Dna5String merge_seqs(const Dna5String &lseq, const Dna5String &rseq, 
-								 const CharString &lq, const CharString &rq, size_t pos) {
-		Dna5String result = lseq;
-		size_t llen = length(lseq), rlen = length(rseq);
-		for (size_t i = pos; i < min(llen, pos + rlen); ++i) {
-			if (result[i] == 'N') {
-				result[i] = rseq[i - pos];
-				continue;
+			Dna5String merge_seqs(const Dna5String &lseq, const Dna5String &rseq, 
+					const CharString &lq, const CharString &rq, size_t pos) {
+				Dna5String result = lseq;
+				size_t left_len = length(lseq), right_len = length(rseq);
+				for (size_t i = pos; i < min(left_len, pos + right_len); ++i) {
+					if (result[i] == 'N') {
+						result[i] = rseq[i - pos];
+						continue;
+					}
+					if (lq[i] < rq[i - pos] && rq[i - pos] != 'N') {
+						result[i] = rseq[i - pos];
+					}
+				}
+				append(result, suffix(rseq, min(left_len - pos, right_len)));
+				return result;
 			}
-			if (lq[i] < rq[i - pos] && rq[i - pos] != 'N') {
-				result[i] = rseq[i - pos];
+			CharString merge_quals(const Dna5String &lseq, const Dna5String &rseq, 
+					const CharString &lqual, const CharString &rqual, size_t pos, size_t base_quality) {
+				CharString result = lqual;
+				size_t left_len = length(lseq), right_len = length(rseq);
+				for (size_t i = pos; i < min(left_len, pos + right_len); ++i) {
+					if (lseq[i] == 'N' && rseq[i - pos] == 'N') {
+						result[i] = char(base_quality);
+					} else if (lseq[i] == 'N') {
+						result[i] = rqual[i - pos];
+					} else if (rseq[i - pos] == 'N') {
+						result[i] = lqual[i];
+					} else if (lseq[i] == rseq[i - pos]) {
+						result[i] = char(lqual[i] - base_quality + rqual[i - pos]);
+					} else if (lqual[i] < rqual[i - pos]) { 
+						result[i] = rqual[i - pos]; 
+					}
+				}
+				append(result, suffix(rqual, min(left_len - pos, right_len)));
+				return result;
 			}
-		}
-		append(result, suffix(rseq, min(llen - pos, rlen)));
-		return result;
-	}
-	inline CharString merge_quals(const Dna5String &lseq, const Dna5String &rseq, 
-								  const CharString &lqual, const CharString &rqual, size_t pos) {
-		CharString result = lqual;
-		size_t llen = length(lseq), rlen = length(rseq);
-		for (size_t i = pos; i < min(llen, pos + rlen); ++i) {
-			if (lseq[i] == 'N' && rseq[i - pos] == 'N') {
-				result[i] = worst_quality;
-			} else if (lseq[i] == 'N') {
-				result[i] = rqual[i - pos];
-			} else if (rseq[i - pos] == 'N') {
-				result[i] = lqual[i];
-			} else if (lseq[i] == rseq[i - pos]) {
-				result[i] = char(lqual[i] - worst_quality + rqual[i - pos]);
-			} else if (lqual[i] < rqual[i - pos]) { 
-				result[i] = rqual[i - pos]; 
-			}
-		}
-		append(result, suffix(rqual, min(llen - pos, rlen)));
-		return result;
-	}
-public:
-	template <class Pairer>
-	pair <Read, bool> Merge(const Read &left, const Read &right, const Pairer &pairer, size_t index) {
-		PairerInfo info = pairer.find_best_overlap(left.seq, right.seq);
-		if (info.position == INFTY) {
-			return (make_pair(Read(), false));
-		}
-		CharString new_id = merge_ids(left.id, index);
-		CharString new_qual = merge_quals(left.seq, right.seq, left.qual, right.qual, info.position);
-		Dna5String new_seq = merge_seqs(left.seq, right.seq, left.qual, right.qual, info.position);
-		assert(length(new_qual) == length(new_seq));
-		return make_pair(Read(new_id, new_qual, new_seq), true);
-	}
-};
-
+		public:
+			template <class Pairer>
+				pair <Read, bool> Merge(const Read &left, const Read &right, const Pairer &pairer, size_t index) {
+					PairerInfo info = pairer.find_best_overlap(left.seq, right.seq);
+					if (info.position == INFTY) {
+						return (make_pair(Read(), false));
+					}
+					CharString new_id = merge_ids(left.id, index);
+					CharString new_qual = merge_quals(left.seq, right.seq, left.qual, right.qual, info.position, pairer.quality());
+					Dna5String new_seq = merge_seqs(left.seq, right.seq, left.qual, right.qual, info.position);
+					assert(length(new_qual) == length(new_seq));
+					return make_pair(Read(new_id, new_qual, new_seq), true);
+				}
+	};
 }


### PR DESCRIPTION
Переписанная версия paired_read_merger'a. 
Добавлена возможность передать параметры в командной строке, но в связи с этим изменился вызов (принимает полноценную командную строку, а не три названия файлов.
Появилась возможность читать риды из нескольких файлов.
