### PR TITLE
Umi testing fixes

### DIFF
--- a/ext/include/seqan/basic/profiling.h
+++ b/ext/include/seqan/basic/profiling.h
@@ -37,6 +37,12 @@
 // TODO(holtgrew): This could use some cleanup.
 
 #include <ctime>
+#ifndef PLATFORM_WINDOWS
+    #ifndef SEQAN_USE_CLOCKGETTIME
+    /* some systems e.g. darwin have no clock_gettime */
+        #include <sys/time.h>
+    #endif
+#endif
 
 //SEQAN_NO_GENERATED_FORWARDS: no forwards are generated for this file
 
@@ -256,7 +262,6 @@ namespace seqan
         #ifndef SEQAN_USE_CLOCKGETTIME
         /* some systems e.g. darwin have no clock_gettime */
 
-            #include <sys/time.h>
 
             inline _proFloat sysTime() {
                 struct timeval tp;

--- a/src/umi_experiments/disjoint_sets.hpp
+++ b/src/umi_experiments/disjoint_sets.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <bits/unordered_map.h>
+#include <unordered_map>
 #include <verify.hpp>
 
 template <typename T, typename Hash = std::hash<T>>

--- a/src/umi_experiments/naive/umi_naive.cpp
+++ b/src/umi_experiments/naive/umi_naive.cpp
@@ -69,13 +69,18 @@ seqan::Dna5String calculate_consensus(const std::vector<seqan::Dna5String>& read
             consensus = seqan::Dna5String(reads[idx]);
         }
     }
+
+    auto GetIndexNucl = [](const seqan::Dna5 &nucl) {
+        return static_cast<size_t>(seqan::ordValue(nucl));
+    };
+
     for (size_t pos = 0; pos < length(consensus); pos ++) {
         std::vector<size_t> nt_counts(4);
         for (size_t idx : idx_list) {
-            nt_counts[reads[idx][pos]] ++;
+            nt_counts[GetIndexNucl(reads[idx][pos])] ++;
         }
         for (size_t i = 0; i < 4; i ++) {
-            if (nt_counts[i] > nt_counts[consensus[pos]]) {
+            if (nt_counts[i] > nt_counts[GetIndexNucl(consensus[pos])]) {
                 consensus[pos] = i;
             }
         }


### PR DESCRIPTION
Fixed:
------
1. Seqan #include in namespace "seqan"
2. disjoint_sets.hpp: #include <bits/unordered_map.h> -> #unclude <unordered_map>
3. umi_naive.cpp: Added cast for Dna5 to size_t.